### PR TITLE
Support URL-encoded asset names in getBaseImageUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## master
+
+- Support asset names that are URL-encoded by Cloudinary in `getBaseImageUrl`.
+
 ## [0.0.1](https://github.com/trivago/babel-plugin-cloudinary/tree/0.0.1)
 
 - First release with documented APIs for `__buildCloudinaryUrl` and `cloudinaryrc.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## master
 
-- Support asset names that are URL-encoded by Cloudinary in `getBaseImageUrl`.
+### Bugfix
+
+- [#7](https://github.com/trivago/babel-plugin-cloudinary/issues/7) Support asset names in `getBaseImageUrl` that are URL-encoded by Cloudinary API.
 
 ## [0.0.1](https://github.com/trivago/babel-plugin-cloudinary/tree/0.0.1)
 

--- a/lib/cloudinary-proxy.js
+++ b/lib/cloudinary-proxy.js
@@ -38,7 +38,7 @@ function getBaseImageUrl(assetName, transforms) {
     url = url.replace(BASE_URL_PLACEHOLDER, runConfig.host);
   }
 
-  return url.split(assetName)[0];
+  return decodeURIComponent(url).split(assetName)[0];
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9660,6 +9660,12 @@
       "dev": true,
       "optional": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest": "^24.8.0",
     "lint-staged": "^8.1.3",
     "nodemon": "^1.18.9",
+    "prettier": "^1.18.2",
     "typescript": "^3.2.4"
   },
   "repository": {

--- a/test/cloudinary-proxy.spec.js
+++ b/test/cloudinary-proxy.spec.js
@@ -4,6 +4,7 @@ jest.mock(
   "../cloudinaryrc.json",
   () => ({
     native: {
+      // eslint-disable-next-line camelcase
       cloud_name: "trivago",
       secure: true,
     },
@@ -16,11 +17,13 @@ jest.mock(
 describe("cloudinary-proxy", () => {
   it("has proper output for getBaseImageUrl 1", () => {
     const expected = "https://trivago.images.com/";
+
     expect(getBaseImageUrl("myfile.jpg")).toEqual(expected);
   });
 
   it("has proper output for getBaseImageUrl 2", () => {
     const expected = "https://trivago.images.com/";
+
     expect(getBaseImageUrl("myfile_2@.jpg")).toEqual(expected);
   });
 });

--- a/test/cloudinary-proxy.spec.js
+++ b/test/cloudinary-proxy.spec.js
@@ -1,0 +1,26 @@
+const { getBaseImageUrl } = require("../lib/cloudinary-proxy");
+
+jest.mock(
+  "../cloudinaryrc.json",
+  () => ({
+    native: {
+      cloud_name: "trivago",
+      secure: true,
+    },
+    host: "trivago.images.com",
+    overrideBaseUrl: true,
+  }),
+  { virtual: true }
+);
+
+describe("cloudinary-proxy", () => {
+  it("has proper output for getBaseImageUrl 1", () => {
+    const expected = "https://trivago.images.com/";
+    expect(getBaseImageUrl("myfile.jpg")).toEqual(expected);
+  });
+
+  it("has proper output for getBaseImageUrl 2", () => {
+    const expected = "https://trivago.images.com/";
+    expect(getBaseImageUrl("myfile_2@.jpg")).toEqual(expected);
+  });
+});


### PR DESCRIPTION
#### Reference issue: [#7](https://github.com/trivago/babel-plugin-cloudinary/issues/7)

#### What changed in this PR:
Support asset names in getBaseImageUrl that Cloudinary returns in their URL-encoded form.
