### PR TITLE
Feature/support binary operator in params

### DIFF
--- a/lib/ast-helpers.js
+++ b/lib/ast-helpers.js
@@ -128,7 +128,8 @@ function replaceExpressions(node, placeholder) {
       t.isConditionalExpression(node) ||
       t.isCallExpression(node) ||
       t.isMemberExpression(node) ||
-      t.isTemplateLiteral(node)
+      t.isTemplateLiteral(node) ||
+      t.isBinaryExpression(node)
     ) {
       const nodeKey = `${placeholder}${count || ""}`;
 

--- a/lib/plugin-parameters.js
+++ b/lib/plugin-parameters.js
@@ -44,7 +44,8 @@ const PLUGIN_PARAMETERS = {
           t.isStringLiteral(assetName) ||
           t.isConditionalExpression(assetName) ||
           t.isCallExpression(assetName) ||
-          t.isTemplateLiteral(assetName)
+          t.isTemplateLiteral(assetName) ||
+          t.isBinaryExpression(assetName)
         )
       ) {
         throw new Error(
@@ -88,11 +89,13 @@ function commonValidator(name, node) {
       t.isStringLiteral(node) ||
       t.isConditionalExpression(node) ||
       t.isCallExpression(node) ||
-      t.isTemplateLiteral(node)
+      t.isTemplateLiteral(node) ||
+      t.isBinaryExpression(node)
     )
   ) {
     throw new Error(
-      `${name} must be one of: identifier, stringLiteral, templateLiteral, conditionalExpression or callExpression`
+      `${name} must be one of: identifier, stringLiteral, templateLiteral,\
+conditionalExpression, callExpression or binaryExpression`
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cloudinary-core": "^2.6.2",
     "eslint": "^5.12.1",
     "eslint-config-recommended": "^4.0.0",
-    "eslint-plugin-jest": "^22.2.1",
+    "eslint-plugin-jest": "^22.15.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^1.3.1",

--- a/test/fixtures/options-prefix-not-valid/__snapshots__/options-prefix-not-valid.spec.js.snap
+++ b/test/fixtures/options-prefix-not-valid/__snapshots__/options-prefix-not-valid.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`options-prefix-not-valid 1`] = `[Error: unknown: prefix must be one of: identifier, stringLiteral, templateLiteral, conditionalExpression or callExpression]`;
+exports[`options-prefix-not-valid 1`] = `[Error: unknown: prefix must be one of: identifier, stringLiteral, templateLiteral,conditionalExpression, callExpression or binaryExpression]`;

--- a/test/fixtures/parameters-with-binary-expression/__snapshots__/parameters-with-binary-expression.spec.js.snap
+++ b/test/fixtures/parameters-with-binary-expression/__snapshots__/parameters-with-binary-expression.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parameters-with-binary-expression 1`] = `
+"function getUrl() {
+  const myPicture = \\"my-picture\\";
+  const baseQuality = \\"auto\\";
+  const baseRadius = 20;
+
+  return \`https://res.cloudinary.com/trivago/image/upload/c_fill,h_333,q_\${\`\${baseQuality}:\${isMobile() ? \\"eco\\" : \\"best\\"}\`},r_\${baseRadius + \\":\\" + \\"0:25:25\\"},t_crop,w_333/\${myPicture + \`.jpeg\`}\${\\"\\"}\${\\"\\"}\${\\"\\"}\${\\"\\"}\`;
+}"
+`;

--- a/test/fixtures/parameters-with-binary-expression/input.js
+++ b/test/fixtures/parameters-with-binary-expression/input.js
@@ -1,0 +1,17 @@
+function getUrl() {
+  const myPicture = "my-picture";
+  const baseQuality = "auto";
+  const baseRadius = 20;
+
+  return __buildCloudinaryUrl(myPicture + `.jpeg`, {
+    transforms: {
+      transformation: "crop",
+      crop: "fill",
+      quality: `${baseQuality}:${isMobile() ? "eco" : "best"}`,
+      width: 333,
+      height: 333,
+      drp: "2.0",
+      radius: baseRadius + ":" + "0:25:25",
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,7 +1988,7 @@ eslint-plugin-import@^2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jest@^22.2.1:
+eslint-plugin-jest@^22.15.1:
   version "22.15.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.15.1.tgz#54c4a752a44c4bc5a564ecc22b32e1cd16a2961a"
   integrity sha512-CWq/RR/3tLaKFB+FZcCJwU9hH5q/bKeO3rFP8G07+q7hcDCFNqpvdphVbEbGE6o6qo1UbciEev4ejUWv7brUhw==


### PR DESCRIPTION
#### What changed in this PR:

- Support [binaryExpressions](https://babeljs.io/docs/en/babel-types#binaryexpression) for string concatenation. Although devs are these days choosing template literals for string interpolation and dropping the binary operator `+` for concatenating strings, there are no reasons why we should not support the operator so that devs can pass binary operations within the `__buildCloudinaryUrl` parameters.
