### PR TITLE
Update eslint-utils to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [#14](https://github.com/trivago/babel-plugin-cloudinary/pull/14) Update [eslint-utils](https://github.com/mysticatea/eslint-utils) to version [1.4.2](https://github.com/mysticatea/eslint-utils/commit/4e1bc077c2a6bb00538d66b69a63c24de3463bed).
+- [#13](https://github.com/trivago/babel-plugin-cloudinary/pull/13) Support binary operators within plugin parameters (e.g. concatenating strings with `+`).
 - [#12](https://github.com/trivago/babel-plugin-cloudinary/pull/12) Global default cloudinary transforms with `defaultTransforms`.
 
 ## [0.0.3](https://github.com/trivago/babel-plugin-cloudinary/tree/0.0.3)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "babel-types": "^6.26.0",
+    "eslint-utils": "1.4.2",
     "lodash": "^4.17.13"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,7 +2055,7 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
+eslint-utils@1.4.2, eslint-utils@^1.3.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==


### PR DESCRIPTION
#### What changed in this PR:

- Upgrade `eslint-utils` to 1.4.2 [commit in eslint-utils](https://github.com/mysticatea/eslint-utils/commit/08158db1c98fd71cf0f32ddefbc147e2620e724c)
